### PR TITLE
Add panel proposal submission CTA to Programming page

### DIFF
--- a/programming.md
+++ b/programming.md
@@ -10,6 +10,13 @@ permalink: /programming/
     <p class="fs-5 mb-0" style="color: #555;">We're working hard to get everything ready. Check back soon for more info!</p>
 </div>
 
+<div class="card p-4 mx-auto shadow-lg rounded my-4" style="background: rgba(255,255,255,0.95);">
+    <h3 class="fw-bold" style="color: #234c41;">Looking to host a panel or activity at Camp Flaw?</h3>
+    <p class="fs-5">We'd love to hear from you!</p>
+    <p class="fs-5">Please complete the form below to submit your proposal.</p>
+    <a href="https://forms.gle/ZmtEEYNd5Udk18JT6" class="btn btn-primary btn-lg align-self-start" target="_blank" rel="noopener">Submit Your Proposal</a>
+</div>
+
 Panels, games, outdoor activities, and evening events. Participation is voluntary.
 
 <img src="/assets/prog1.jpeg" alt="Programming activities" class="img-fluid rounded shadow my-4 w-100">
@@ -19,10 +26,3 @@ Panels, games, outdoor activities, and evening events. Participation is voluntar
 <img src="/assets/prog4.jpeg" alt="Programming activities" class="img-fluid rounded shadow my-4 w-100">
 
 <img src="/assets/prog5.jpeg" alt="Programming activities" class="img-fluid rounded shadow my-4 w-100">
-
-<div class="card p-4 mx-auto shadow-lg rounded my-4" style="background: rgba(255,255,255,0.95);">
-    <h3 class="fw-bold" style="color: #234c41;">Looking to host a panel or activity at Camp Flaw?</h3>
-    <p class="fs-5">We'd love to hear from you!</p>
-    <p class="fs-5">Please complete the form below to submit your proposal.</p>
-    <a href="https://forms.gle/ZmtEEYNd5Udk18JT6" class="btn btn-primary btn-lg align-self-start" target="_blank" rel="noopener">Submit Your Proposal</a>
-</div>

--- a/programming.md
+++ b/programming.md
@@ -19,3 +19,10 @@ Panels, games, outdoor activities, and evening events. Participation is voluntar
 <img src="/assets/prog4.jpeg" alt="Programming activities" class="img-fluid rounded shadow my-4 w-100">
 
 <img src="/assets/prog5.jpeg" alt="Programming activities" class="img-fluid rounded shadow my-4 w-100">
+
+<div class="card p-4 mx-auto shadow-lg rounded my-4" style="background: rgba(255,255,255,0.95);">
+    <h3 class="fw-bold" style="color: #234c41;">Looking to host a panel or activity at Camp Flaw?</h3>
+    <p class="fs-5">We'd love to hear from you!</p>
+    <p class="fs-5">Please complete the form below to submit your proposal.</p>
+    <a href="https://forms.gle/ZmtEEYNd5Udk18JT6" class="btn btn-primary btn-lg align-self-start" target="_blank" rel="noopener">Submit Your Proposal</a>
+</div>


### PR DESCRIPTION
## Summary
- Adds a call-to-action card on the Programming page inviting folks to submit panel/activity proposals via the Google Form (https://forms.gle/ZmtEEYNd5Udk18JT6)

## Test plan
- [ ] Visit /programming/ and confirm the new proposal card renders below the programming images
- [ ] Confirm the "Submit Your Proposal" button links to the correct form and opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)