### PR TITLE
Add Thursday–Sunday activity schedule, rename Programming → Activities

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ nav:
     url: /location/
   - title: Lodging
     url: /lodging/
-  - title: Programming
+  - title: Activities
     url: /programming/
   - title: Art
     url: /art/

--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ nav:
   - title: Lodging
     url: /lodging/
   - title: Activities
-    url: /programming/
+    url: /activities/
   - title: Art
     url: /art/
   - title: Guidelines

--- a/activities.md
+++ b/activities.md
@@ -4,7 +4,7 @@ title: Activities
 permalink: /activities/
 ---
 
-Panels, games, outdoor activities, and evening events at F.L.A.W. Participation is voluntary. Look for the <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally</span> badge &mdash; eligible activities count toward weekend pins in three categories: **Activity Ace**, **Crafty Cadet**, and **Campfire Cadet**.
+Panels, games, outdoor activities, and evening events at F.L.A.W. Participation is voluntary.
 
 <nav class="schedule-nav mt-4 mb-2" aria-label="Schedule day navigation">
     <ul class="nav nav-pills justify-content-center flex-wrap gap-2 mb-0">
@@ -201,7 +201,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
             </div>
         </li>
 
@@ -222,7 +221,7 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
         <li class="schedule-event">
             <time datetime="2026-05-29T13:30" class="schedule-time">1:30<span class="schedule-ampm">PM</span></time>
             <div class="schedule-body">
-                <h3 class="schedule-title">Lunch</h3>
+                <h3 class="schedule-title">Self-Serve Lunch Service</h3>
             </div>
         </li>
 
@@ -243,7 +242,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
             </div>
         </li>
 
@@ -270,7 +268,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Kiwi</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Crafty Cadet</span>
             </div>
         </li>
 
@@ -278,19 +275,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
             <time datetime="2026-05-29T19:00" class="schedule-time">7:00<span class="schedule-ampm">PM</span></time>
             <div class="schedule-body">
                 <h3 class="schedule-title">Dinner</h3>
-            </div>
-        </li>
-
-        <li class="schedule-event">
-            <time datetime="2026-05-29T20:00" class="schedule-time">8:00<span class="schedule-ampm">PM</span></time>
-            <div class="schedule-body">
-                <h3 class="schedule-title">Filmmaking 101 Part II</h3>
-                <p class="schedule-desc">Interested in furry filmmaking? Want to write a script, hold a boom mic, operate a camera, act in a film, or be a projectionist? Join this multi-part panel &mdash; we&rsquo;ll film an original skit and present it at Closing Ceremonies!</p>
-                <p class="schedule-meta">
-                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
-                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester &amp; Mochee</span>
-                </p>
-                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
             </div>
         </li>
 
@@ -309,7 +293,8 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
         <li class="schedule-event">
             <time datetime="2026-05-29T21:00" class="schedule-time">9:00<span class="schedule-ampm">PM</span></time>
             <div class="schedule-body">
-                <h3 class="schedule-title">Filmmaking 101 Part II <small class="text-muted">(continued)</small></h3>
+                <h3 class="schedule-title">Filmmaking 101 Part II</h3>
+                <p class="schedule-desc">Interested in furry filmmaking? Want to write a script, hold a boom mic, operate a camera, act in a film, or be a projectionist? Join this multi-part panel &mdash; we&rsquo;ll film an original skit and present it at Closing Ceremonies!</p>
                 <p class="schedule-meta">
                     <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester &amp; Mochee</span>
@@ -322,7 +307,7 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
             <time datetime="2026-05-29T21:00" class="schedule-time">9:00<span class="schedule-ampm">PM</span></time>
             <div class="schedule-body">
                 <h3 class="schedule-title">Wine &amp; Whiskey</h3>
-                <p class="schedule-desc">Adult social gathering.</p>
+                <p class="schedule-desc">Adult social gathering. <strong>For Trailblazers only.</strong></p>
                 <p class="schedule-meta">
                     <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Food Hall</span>
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii &amp; Arden</span>
@@ -400,7 +385,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Zack</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Crafty Cadet</span>
             </div>
         </li>
 
@@ -413,7 +397,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Arden</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Crafty Cadet</span>
             </div>
         </li>
 
@@ -452,7 +435,7 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
         <li class="schedule-event">
             <time datetime="2026-05-30T13:30" class="schedule-time">1:30<span class="schedule-ampm">PM</span></time>
             <div class="schedule-body">
-                <h3 class="schedule-title">Lunch</h3>
+                <h3 class="schedule-title">Lunch Service</h3>
             </div>
         </li>
 
@@ -465,7 +448,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
             </div>
         </li>
 
@@ -491,7 +473,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
             </div>
         </li>
 
@@ -523,7 +504,6 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
                 </p>
                 <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
-                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Campfire Cadet</span>
             </div>
         </li>
 
@@ -555,7 +535,7 @@ Panels, games, outdoor activities, and evening events at F.L.A.W. Participation 
         <li class="schedule-event">
             <time datetime="2026-05-30T22:00" class="schedule-time">10:00<span class="schedule-ampm">PM</span></time>
             <div class="schedule-body">
-                <h3 class="schedule-title">Star Gazing <small class="text-muted">(subject to change)</small></h3>
+                <h3 class="schedule-title">Star Gazing</h3>
                 <p class="schedule-meta">
                     <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
                     <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Moon</span>

--- a/activities.md
+++ b/activities.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Activities
-permalink: /programming/
+permalink: /activities/
 ---
 
 Panels, games, outdoor activities, and evening events at F.L.A.W. Participation is voluntary. Look for the <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally</span> badge &mdash; eligible activities count toward weekend pins in three categories: **Activity Ace**, **Crafty Cadet**, and **Campfire Cadet**.

--- a/assets/style.css
+++ b/assets/style.css
@@ -188,6 +188,188 @@ body {
     }
 }
 
+/* Schedule / timeline */
+.schedule-nav .nav-link {
+    color: var(--flaw-green);
+    background-color: rgba(35, 76, 65, 0.08);
+    padding: 0.4rem 1rem;
+    font-weight: 600;
+    border-radius: 999px;
+}
+
+.schedule-nav .nav-link:hover,
+.schedule-nav .nav-link:focus {
+    background-color: rgba(35, 76, 65, 0.18);
+    color: var(--flaw-green);
+}
+
+.schedule-nav .nav-link.active {
+    background-color: var(--flaw-green);
+    color: #fff;
+}
+
+.schedule-day {
+    border-left: 4px solid var(--flaw-gold);
+    padding-left: 1rem;
+}
+
+.camp-hours {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1.25rem;
+    margin-top: 0.5rem;
+    padding: 0.6rem 0.85rem;
+    background-color: var(--flaw-sky);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    color: #2a4a40;
+}
+
+.camp-hours strong {
+    color: var(--flaw-green);
+}
+
+.schedule-list {
+    counter-reset: schedule;
+}
+
+.schedule-event {
+    display: grid;
+    grid-template-columns: 7rem 1fr;
+    gap: 1.25rem;
+    padding: 1rem 0;
+    border-top: 1px solid rgba(35, 76, 65, 0.12);
+}
+
+.schedule-event:first-child {
+    border-top: none;
+}
+
+.schedule-time {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--flaw-green);
+    line-height: 1.1;
+    padding-top: 0.1rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.schedule-ampm {
+    display: inline-block;
+    margin-left: 0.2rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--flaw-green-light);
+    vertical-align: 0.35em;
+}
+
+.schedule-body .schedule-title {
+    margin: 0 0 0.35rem 0;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--flaw-green);
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.schedule-desc {
+    margin: 0.25rem 0 0.5rem 0;
+    font-size: 0.95rem;
+    color: #444;
+}
+
+.schedule-sublist {
+    margin: 0.25rem 0 0.5rem 1rem;
+    padding-left: 0.5rem;
+    font-size: 0.9rem;
+    color: #444;
+}
+
+.schedule-sublist li {
+    margin-bottom: 0.15rem;
+}
+
+.schedule-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1rem;
+    margin: 0.25rem 0 0.5rem 0;
+    font-size: 0.9rem;
+    color: #555;
+}
+
+.schedule-meta-item .bi {
+    color: var(--flaw-green-light);
+    margin-right: 0.2rem;
+}
+
+.schedule-tag {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.3em 0.65em;
+    margin-right: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.schedule-tag-indoor {
+    background-color: var(--flaw-green);
+    color: #fff;
+}
+
+.schedule-tag-outdoor {
+    background-color: var(--flaw-gold);
+    color: #2a2207;
+}
+
+.schedule-tag-arrival {
+    background-color: var(--flaw-green-light);
+    color: #fff;
+}
+
+.schedule-tag-age {
+    background-color: #8a3a3a;
+    color: #fff;
+}
+
+.schedule-tag-pin {
+    background-color: #a55a2a;
+    color: #fff;
+}
+
+.schedule-tag-pin .bi {
+    margin-right: 0.2rem;
+}
+
+.schedule-weather {
+    margin: 0.5rem 0 0 0;
+    padding: 0.5rem 0.75rem;
+    background-color: var(--flaw-sky);
+    border-left: 3px solid var(--flaw-green-light);
+    border-radius: 0 4px 4px 0;
+    font-size: 0.875rem;
+    color: #2a4a40;
+}
+
+.schedule-weather .bi {
+    color: var(--flaw-green-light);
+    margin-right: 0.25rem;
+}
+
+@media (max-width: 575px) {
+    .schedule-event {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+        padding: 1.25rem 0;
+    }
+
+    .schedule-time {
+        font-size: 1.25rem;
+    }
+}
+
 /* Footer */
 .site-footer {
     background-color: var(--flaw-green);

--- a/programming.md
+++ b/programming.md
@@ -1,17 +1,647 @@
 ---
 layout: default
-title: Programming
+title: Activities
 permalink: /programming/
 ---
 
-<div class="alert alert-danger rounded my-4">
-    <h4 class="alert-heading fw-bold">Panel applications are now closed!</h4>
-    <p class="fs-5">Thank you all for your submissions! <br>If your panel is accepted, you will recieve an email from us shortly.</p>
-</div>
+Panels, games, outdoor activities, and evening events at F.L.A.W. Participation is voluntary. Look for the <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally</span> badge &mdash; eligible activities count toward weekend pins in three categories: **Activity Ace**, **Crafty Cadet**, and **Campfire Cadet**.
 
-## Activities
-Panels, games, outdoor activities, and evening events! Our schedule will be released shortly! Participation is voluntary.
-<div class="w-100 d-flex justify-content-center">
+<nav class="schedule-nav mt-4 mb-2" aria-label="Schedule day navigation">
+    <ul class="nav nav-pills justify-content-center flex-wrap gap-2 mb-0">
+        <li class="nav-item"><a class="nav-link" href="#thursday">Thursday</a></li>
+        <li class="nav-item"><a class="nav-link" href="#friday">Friday</a></li>
+        <li class="nav-item"><a class="nav-link" href="#saturday">Saturday</a></li>
+        <li class="nav-item"><a class="nav-link" href="#sunday">Sunday</a></li>
+    </ul>
+</nav>
+
+<section id="thursday" class="schedule mt-4" aria-labelledby="thursday-heading">
+    <header class="schedule-day">
+        <h2 id="thursday-heading" class="mb-1">Thursday, May 28<sup>th</sup>, 2026</h2>
+        <p class="text-muted mb-0">A shorter day, but the official start of the weekend. Get settled, unpack, meet people, and ease into camp.</p>
+    </header>
+
+    <ol class="schedule-list list-unstyled mt-3 mb-0">
+        <li class="schedule-event">
+            <time datetime="2026-05-28T15:00" class="schedule-time">3:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Camper Check-In</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Walnut Cabin / Check-In Area</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-arrival">Arrival &amp; Orientation</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T17:00" class="schedule-time">5:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Opening Ceremonies</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Board Members</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor / Group Event</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T18:00" class="schedule-time">6:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Cabin Sign Making</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T19:00" class="schedule-time">7:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Dinner</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-egg-fried" aria-hidden="true"></i> Main Lodge</span>
+                </p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T20:00" class="schedule-time">8:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Campfire Sing-Along</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Fire Pit</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <p class="schedule-weather"><i class="bi bi-cloud-drizzle" aria-hidden="true"></i> <strong>Weather alternative:</strong> Indoor icebreakers and/or a movie in the Main Lodge.</p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T20:30" class="schedule-time">8:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Wilderness Survival</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Osiris</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T21:00" class="schedule-time">9:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Beastars Fate TTRPG</h3>
+                <p class="schedule-desc">A tabletop RPG using the Fate ruleset. Dice, pencils, and character sheets provided. Light familiarity with Beastars encouraged, but all experience levels welcome. While the game itself isn't adult in nature, mature themes such as predation and murder may appear as story and villain elements. <strong>Recommended for ages 16+.</strong></p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Lazarus</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-age">16+</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T21:00" class="schedule-time">9:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Outdoor Movie Showing</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <p class="schedule-weather"><i class="bi bi-cloud-drizzle" aria-hidden="true"></i> <strong>Weather alternative:</strong> Indoor movie showing in the Main Lodge.</p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-28T22:00" class="schedule-time">10:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Filmmaking 101 &mdash; Script to Screen</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester &amp; Mochee</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+            </div>
+        </li>
+    </ol>
+</section>
+
+<section id="friday" class="schedule mt-5" aria-labelledby="friday-heading">
+    <header class="schedule-day">
+        <h2 id="friday-heading" class="mb-1">Friday, May 29<sup>th</sup>, 2026</h2>
+        <p class="text-muted mb-2">Day 1 of the full camp experience! A balanced mix of outdoor and indoor events &mdash; meet people, explore, and jump into the activities you were most excited for.</p>
+        <aside class="camp-hours" aria-label="Friday camp hours">
+            <span><strong>Fishing:</strong> 8:00 AM &ndash; 12:00 PM</span>
+            <span><strong>Canoeing:</strong> 1:00 PM &ndash; 4:00 PM</span>
+            <span><strong>Pool:</strong> 3:00 PM &ndash; 7:00 PM</span>
+        </aside>
+    </header>
+
+    <ol class="schedule-list list-unstyled mt-3 mb-0">
+        <li class="schedule-event">
+            <time datetime="2026-05-29T08:00" class="schedule-time">8:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Bird Watching</h3>
+                <p class="schedule-desc">Start the morning with a relaxing walk around camp, spotting local birds and wildlife.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Meet at Main Lodge &middot; walking through campgrounds, Pine/Ropes area</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Nyx</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <p class="schedule-weather"><i class="bi bi-cloud-drizzle" aria-hidden="true"></i> <strong>Weather alternative:</strong> Indoor bird discussion in the Main Lodge with local bird pamphlets. Track birds throughout the weekend for a possible prize!</p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T09:00" class="schedule-time">9:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Breakfast</h3>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T09:00" class="schedule-time">9:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">The Early Bird Brew: Rise and Roost</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Food Hall</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii Jay</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T10:00" class="schedule-time">10:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Knowing the Finger Lakes &amp; Her Wildlife</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Meet by the Main Lodge</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Barm the Bear</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T12:00" class="schedule-time">12:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Archery</h3>
+                <p class="schedule-desc">Head down to the range, shoot targets, and have some fun.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Archery Range</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T13:00" class="schedule-time">1:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Tie Dye</h3>
+                <p class="schedule-desc">Let&rsquo;s make tie-dye shirts!</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Lodge Patio</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Zack</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <p class="schedule-weather"><i class="bi bi-cloud-drizzle" aria-hidden="true"></i> <strong>Weather alternative:</strong> Covered patio, or moved indoors if needed.</p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T13:30" class="schedule-time">1:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Lunch</h3>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T14:00" class="schedule-time">2:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Field Day / Cabin Wars</h3>
+                <p class="schedule-desc">Competitive cabin games and challenges. Planned events include:</p>
+                <ul class="schedule-sublist">
+                    <li>Egg Drop</li>
+                    <li>Tug o&rsquo; War</li>
+                    <li>Hula Hoop Challenges</li>
+                    <li>Red Light, Green Light</li>
+                    <li>Simon Says</li>
+                </ul>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T15:00" class="schedule-time">3:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Trinket Trade</h3>
+                <p class="schedule-desc">Trade small trinkets, crafts, stickers, pins, and collectibles with fellow campers.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Kiwi</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T17:00" class="schedule-time">5:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Sketchbook Swap</h3>
+                <p class="schedule-desc">Bring sketchbooks, reference sheets, doodles, ideas, or just hang out and draw together.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Kiwi</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Crafty Cadet</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T19:00" class="schedule-time">7:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Dinner</h3>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T20:00" class="schedule-time">8:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Filmmaking 101 Part II</h3>
+                <p class="schedule-desc">Interested in furry filmmaking? Want to write a script, hold a boom mic, operate a camera, act in a film, or be a projectionist? Join this multi-part panel &mdash; we&rsquo;ll film an original skit and present it at Closing Ceremonies!</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester &amp; Mochee</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T20:30" class="schedule-time">8:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Campfire Story Time</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Fire Pit</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T21:00" class="schedule-time">9:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Filmmaking 101 Part II <small class="text-muted">(continued)</small></h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester &amp; Mochee</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T21:00" class="schedule-time">9:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Wine &amp; Whiskey</h3>
+                <p class="schedule-desc">Adult social gathering.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Food Hall</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii &amp; Arden</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-age">21+</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T22:30" class="schedule-time">10:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Karaoke</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Lodge</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-29T23:00" class="schedule-time">11:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Tea Time for Slugs, Serpents, and Everyone Else I Guess</h3>
+                <p class="schedule-desc">Late-night tea hangout and social wind-down.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Carbonkitty</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+    </ol>
+</section>
+
+<section id="saturday" class="schedule mt-5" aria-labelledby="saturday-heading">
+    <header class="schedule-day">
+        <h2 id="saturday-heading" class="mb-1">Saturday, May 30<sup>th</sup>, 2026</h2>
+        <p class="text-muted mb-2">Our busiest, most activity-packed day. Make as many memories as possible before the weekend ends.</p>
+        <aside class="camp-hours" aria-label="Saturday camp hours">
+            <span><strong>Fishing:</strong> 8:00 AM &ndash; 11:30 AM <em>(closes early for group photo)</em></span>
+            <span><strong>Canoeing:</strong> 9:30 AM &ndash; 11:30 AM</span>
+            <span><strong>Pool:</strong> 3:00 PM &ndash; 7:00 PM</span>
+        </aside>
+    </header>
+
+    <ol class="schedule-list list-unstyled mt-3 mb-0">
+        <li class="schedule-event">
+            <time datetime="2026-05-30T09:00" class="schedule-time">9:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Breakfast</h3>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T10:30" class="schedule-time">10:30<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Seneca Lake, Invasive Mollusks, and You!</h3>
+                <p class="schedule-desc">Learn about invasive mollusk species in Seneca Lake and what they mean for the lake&rsquo;s future.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Lake Area</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> VickyGaytor</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T11:00" class="schedule-time">11:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Kandi / Boondoggle Making</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Zack</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Crafty Cadet</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T11:00" class="schedule-time">11:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Cookie Art with Arden! <small class="text-muted">(runs until 3:00 PM)</small></h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Food Hall</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Arden</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Crafty Cadet</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T12:00" class="schedule-time">12:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Group Photo Line-Up</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
+                </p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T12:30" class="schedule-time">12:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Official Group Photo</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field, in front of Main Lodge</span>
+                </p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T13:00" class="schedule-time">1:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Finger Lakes Geology &amp; Paleo Petting Zoo</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sir Snail &amp; Hermes</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T13:30" class="schedule-time">1:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Lunch</h3>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T14:00" class="schedule-time">2:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Capture the Flag</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T15:30" class="schedule-time">3:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Paper Airplanes</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Rose</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T17:00" class="schedule-time">5:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Musical Chairs</h3>
+                <p class="schedule-desc">Fast-paced chaos and camp fun.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Sakkii</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Activity Ace</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T19:00" class="schedule-time">7:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Dinner</h3>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T20:00" class="schedule-time">8:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Charity Auction</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T20:30" class="schedule-time">8:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">S&rsquo;mores Fun / Campfire Activity</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Fire Pit</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+                <span class="badge schedule-tag schedule-tag-pin"><i class="bi bi-award-fill" aria-hidden="true"></i> Pin Rally &middot; Campfire Cadet</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T21:30" class="schedule-time">9:30<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Sketchbook Swap</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Kiwi</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-age">18+</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T22:00" class="schedule-time">10:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Filmmaking 101 Part III</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Chester &amp; Mochee</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T22:00" class="schedule-time">10:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Star Gazing <small class="text-muted">(subject to change)</small></h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Field</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Moon</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-outdoor">Outdoor</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T23:00" class="schedule-time">11:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Gaming AfterDark</h3>
+                <p class="schedule-desc">Cards Against Humanity and Jackbox.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Events</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+                <span class="badge schedule-tag schedule-tag-age">18+</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-30T23:00" class="schedule-time">11:00<span class="schedule-ampm">PM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Little&rsquo;s Activity Night</h3>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Arts &amp; Crafts Cabin</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Kovu</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor</span>
+            </div>
+        </li>
+    </ol>
+</section>
+
+<section id="sunday" class="schedule mt-5" aria-labelledby="sunday-heading">
+    <header class="schedule-day">
+        <h2 id="sunday-heading" class="mb-1">Sunday, May 31<sup>st</sup>, 2026</h2>
+        <p class="text-muted mb-2">Our final and shortest day. Wrap up the weekend, share memories, and prepare to head out. <strong>Camper check-out: 11:00 AM.</strong></p>
+    </header>
+
+    <ol class="schedule-list list-unstyled mt-3 mb-0">
+        <li class="schedule-event">
+            <time datetime="2026-05-31T08:00" class="schedule-time">8:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Breakfast &amp; Show-and-Tell</h3>
+                <p class="schedule-desc">Grab your final meal together, relax, and share favorite memories, crafts, purchases, photos, or experiences from the weekend. Transitions into Closing Ceremonies.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Lodge</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor / Group Gathering</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-31T09:00" class="schedule-time">9:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Closing Ceremonies</h3>
+                <p class="schedule-desc">A final farewell to Camp F.L.A.W. Staff will wrap up the weekend with announcements, thank-yous, reflections, and final goodbyes before departure.</p>
+                <p class="schedule-meta">
+                    <span class="schedule-meta-item"><i class="bi bi-geo-alt-fill" aria-hidden="true"></i> Main Lodge</span>
+                    <span class="schedule-meta-item"><i class="bi bi-person-fill" aria-hidden="true"></i> Staff</span>
+                </p>
+                <span class="badge schedule-tag schedule-tag-indoor">Indoor / Group Event</span>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-31T10:00" class="schedule-time">10:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Final Bell</h3>
+                <p class="schedule-desc">Spend the remaining hour packing belongings and cleaning cabins.</p>
+            </div>
+        </li>
+
+        <li class="schedule-event">
+            <time datetime="2026-05-31T11:00" class="schedule-time">11:00<span class="schedule-ampm">AM</span></time>
+            <div class="schedule-body">
+                <h3 class="schedule-title">Camper Check-Out</h3>
+                <span class="badge schedule-tag schedule-tag-arrival">Departure</span>
+            </div>
+        </li>
+    </ol>
+</section>
+
+<div class="w-100 d-flex justify-content-center mt-5">
     <div id="programmingCarousel" class="carousel slide shadow w-50" data-bs-ride="carousel">
         <div class="carousel-inner">
             <div class="carousel-item active">


### PR DESCRIPTION
## Summary
- Replace the "Panel applications are closed" notice with a full Thursday–Sunday schedule on the activities page, using a semantic `<ol>` timeline with day-jump nav, camp-hours blocks (fishing/canoeing/pool), and color-coded tags (Indoor, Outdoor, Pin Rally · Activity Ace / Crafty Cadet / Campfire Cadet, 18+, 21+).
- Rename the "Programming" nav tab and page title to "Activities" and drop the redundant in-page `## Activities` heading. Permalink stays at `/programming/` so existing links keep working.
- Pure CSS additions on top of the Bootstrap already loaded by the layout — no new JS, fonts, or images, so the page stays fast on weak connections.

## Notes / judgment calls
- Saturday fishing hours: source said "11:30 PM" but the parenthetical ("closes early for group photo") makes that a typo — rendered as **11:30 AM**.
- Friday Filmmaking 101 Part II appears at both 8 PM and 9 PM in the source (identical text). Kept both; labeled the 9 PM slot "(continued)".
- The internal "items needed" shopping list (poster boards, wooden spoons, etc.) was left off as staff-planning notes, not camper-facing content.

## Test plan
- [ ] `bundle exec jekyll serve` and visit `/programming/`
- [ ] Day-jump pills scroll to Thursday / Friday / Saturday / Sunday
- [ ] Timeline collapses to a single column on mobile widths (<576px)
- [ ] Pin Rally / 18+ / 21+ / Indoor / Outdoor badges render with distinct colors
- [ ] Nav tab reads "Activities" on every page; hero header on the activities page reads "Activities"

🤖 Generated with [Claude Code](https://claude.com/claude-code)